### PR TITLE
Fix Inchequeable bot Error on subtyped messages

### DIFF
--- a/bonobot/basebot.py
+++ b/bonobot/basebot.py
@@ -59,7 +59,7 @@ class InchequeableBot(BaseBot):
 
     def is_relevant(self, type, text='', **kwargs):
         if type == 'message':
-	    lowcase_text = text.lower()
+            lowcase_text = text.lower()
             return any([line.lower() in lowcase_text for line in self.triggers])
         elif type == 'reaction_added':
             return kwargs['reaction'] == 'inchequeable'

--- a/bonobot/basebot.py
+++ b/bonobot/basebot.py
@@ -57,9 +57,8 @@ class InchequeableBot(BaseBot):
         with open('inchequeable.txt') as f:
             self.triggers = f.read().splitlines()
 
-    def is_relevant(self, type, **kwargs):
+    def is_relevant(self, type, text='', **kwargs):
         if type == 'message':
-            text = kwargs['text'].lower()
             return any([line.lower() in text for line in self.triggers])
         elif type == 'reaction_added':
             return kwargs['reaction'] == 'inchequeable'

--- a/bonobot/basebot.py
+++ b/bonobot/basebot.py
@@ -59,7 +59,7 @@ class InchequeableBot(BaseBot):
 
     def is_relevant(self, type, text='', **kwargs):
         if type == 'message':
-			lowcase_text = text.lower()
+	    lowcase_text = text.lower()
             return any([line.lower() in lowcase_text for line in self.triggers])
         elif type == 'reaction_added':
             return kwargs['reaction'] == 'inchequeable'

--- a/bonobot/basebot.py
+++ b/bonobot/basebot.py
@@ -59,7 +59,8 @@ class InchequeableBot(BaseBot):
 
     def is_relevant(self, type, text='', **kwargs):
         if type == 'message':
-            return any([line.lower() in text for line in self.triggers])
+			lowcase_text = text.lower()
+            return any([line.lower() in lowcase_text for line in self.triggers])
         elif type == 'reaction_added':
             return kwargs['reaction'] == 'inchequeable'
 


### PR DESCRIPTION
InchequeableBot had errors when reading the 'text' field of the event. On subtyped event messages, text field [might not be defined](https://api.slack.com/events/message). Fixed it by setting the default value for text in is_relevant method the same way BaseBot does.

example message event:
```
{
	"type": "message",
	"subtype": "message_changed",
	"hidden": true,
	"channel": "C2147483705",
	"ts": "1358878755.000001",
	"message": {
		"type": "message",
		"user": "U2147483697",
		"text": "Hello, world!",
		"ts": "1355517523.000005",
		"edited": {
			"user": "U2147483697",
			"ts": "1358878755.000001"
		}
	}
}
```

Error in logs:
```
ERROR:bonobot:Exception on /slackbot/bot [POST]

Traceback (most recent call last):

  File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 2446, in wsgi_app

    response = self.full_dispatch_request()

  File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 1951, in full_dispatch_request

    rv = self.handle_user_exception(e)

  File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 1820, in handle_user_exception

    reraise(exc_type, exc_value, tb)

  File "/usr/local/lib/python3.7/site-packages/flask/_compat.py", line 39, in reraise

    raise value

  File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 1949, in full_dispatch_request

    rv = self.dispatch_request()

  File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 1935, in dispatch_request

    return self.view_functions[rule.endpoint](**req.view_args)

  File "/usr/src/app/bonobot/__init__.py", line 34, in bonobot_mention

    if bot.is_relevant(**event):

  File "/usr/src/app/bonobot/basebot.py", line 62, in is_relevant

    text = kwargs['text'].lower()

KeyError: 'text'
```